### PR TITLE
fix: serialize API requests to prevent TV API crash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 All notable changes to this project will be documented in this file.
 
+## [1.0.5] - 2026-02-27
+
+### Fixed
+
+- Serialized all API requests to the TV using a request queue to prevent overwhelming the JointSpace API server, which could crash under concurrent load ([#1](https://github.com/mp-consulting/homebridge-philips-ambilight-tv/issues/1))
+- Added 100ms inter-request delay between consecutive API calls to give the TV time to process each request
+- Delayed initial state polling by 5 seconds after accessory creation to let the TV API stabilize on startup
+- Moved background app fetch after the first poll to avoid concurrent requests on startup
+
 ## [1.0.4] - 2026-02-27
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mp-consulting/homebridge-philips-ambilight-tv",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@mp-consulting/homebridge-philips-ambilight-tv",
-      "version": "1.0.4",
+      "version": "1.0.5",
       "license": "MIT",
       "dependencies": {
         "@homebridge/plugin-ui-utils": "^2.1.2",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@mp-consulting/homebridge-philips-ambilight-tv",
   "displayName": "Philips Ambilight TV",
   "type": "module",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "description": "Homebridge plugin to control Philips Ambilight TV as a HomeKit Television accessory.",
   "author": "Mickael Palma",
   "license": "MIT",


### PR DESCRIPTION
## Summary

- Add a request queue to `PhilipsTVClient` that serializes all API calls (only one HTTP exchange in-flight at a time) with 100ms inter-request delay
- Delay initial state polling by 5 seconds after accessory creation to let the TV API stabilize
- Move background app fetch after the first poll to avoid concurrent requests on startup

Fixes #1 — The TV's lightweight JointSpace API server was crashing under the burst of ~12 HTTP requests the plugin fired within milliseconds on startup.

## Test plan

- [x] `npm run lint` passes
- [x] `npm run build` passes
- [x] Verify TV API no longer crashes on plugin startup
- [x] Verify state polling still works after 5s delay
- [x] Verify onSet handlers (power, volume, ambilight) still work through the request queue