### PR TITLE
fix(api): guard response body read against a stalled TV body

### DIFF
--- a/src/api/utils.ts
+++ b/src/api/utils.ts
@@ -4,7 +4,7 @@
 
 import crypto from 'crypto';
 import dgram from 'dgram';
-import { Agent, type Dispatcher, fetch } from 'undici';
+import { Agent, type Dispatcher, type Headers, fetch } from 'undici';
 import {
   TV_API_PORT, TV_API_VERSION, ERROR_MESSAGES, AUTH_SHARED_KEY,
   WOL_PORT, WOL_BROADCAST_IP, WOL_BURST_COUNT, WOL_PACKETS_PER_BURST, WOL_BURST_INTERVAL_MS,
@@ -42,12 +42,24 @@ export const hmacSignature = (timestamp: string, pin: string): string => {
 export const buildUrl = (ip: string, endpoint: string): string =>
   `https://${ip}:${TV_API_PORT}/${TV_API_VERSION}${endpoint}`;
 
+/**
+ * A fully-read HTTP response. The body is buffered before the response is
+ * returned, so `text()`/`json()` resolve from memory and cannot block.
+ */
+export interface TimedResponse {
+  ok: boolean;
+  status: number;
+  headers: Headers;
+  text: () => Promise<string>;
+  json: () => Promise<unknown>;
+}
+
 export const fetchWithTimeout = async (
   url: string,
   options: { method: string; headers?: Record<string, string>; body?: string; dispatcher?: Dispatcher },
   timeout: number,
   externalSignal?: AbortSignal,
-) => {
+): Promise<TimedResponse> => {
   const controller = new AbortController();
   const timeoutId = setTimeout(() => controller.abort(), timeout);
 
@@ -56,11 +68,31 @@ export const fetchWithTimeout = async (
   externalSignal?.addEventListener('abort', onExternalAbort, { once: true });
 
   try {
-    return await fetch(url, {
+    const response = await fetch(url, {
       ...options,
       signal: controller.signal,
       dispatcher: options.dispatcher || httpsAgent,
     });
+
+    // Read the body while the abort timer is still armed. `fetch` resolves as
+    // soon as the response headers arrive, so a TV that sends headers then
+    // stalls the body would otherwise hang an un-guarded `response.text()`
+    // forever. Buffering here keeps the whole exchange under `timeout`.
+    const bodyText = await response.text();
+
+    return {
+      ok: response.ok,
+      status: response.status,
+      headers: response.headers,
+      text: () => Promise.resolve(bodyText),
+      json: () => {
+        try {
+          return Promise.resolve(JSON.parse(bodyText) as unknown);
+        } catch (error) {
+          return Promise.reject(error instanceof Error ? error : new Error(String(error)));
+        }
+      },
+    };
   } finally {
     clearTimeout(timeoutId);
     externalSignal?.removeEventListener('abort', onExternalAbort);

--- a/test/api/utils.test.ts
+++ b/test/api/utils.test.ts
@@ -1,9 +1,17 @@
-import { describe, it, expect, vi, afterEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import crypto from 'crypto';
+
+vi.mock('undici', async (importOriginal) => {
+  const actual = await importOriginal<Record<string, unknown>>();
+  return { ...actual, fetch: vi.fn() };
+});
+
+import { fetch as undiciFetch } from 'undici';
 import {
   md5,
   hmacSignature,
   buildUrl,
+  fetchWithTimeout,
   parseWwwAuthenticate,
   createDigestAuth,
   parseErrorResponse,
@@ -338,5 +346,59 @@ describe('createDeviceInfo', () => {
     const info1 = createDeviceInfo('Bridge1');
     const info2 = createDeviceInfo('Bridge2');
     expect(info1.id).not.toBe(info2.id);
+  });
+});
+
+// ============================================================================
+// fetchWithTimeout — body read must stay under the deadline (issue #14)
+// ============================================================================
+
+describe('fetchWithTimeout', () => {
+  const mockedFetch = vi.mocked(undiciFetch);
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    mockedFetch.mockReset();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('aborts when the TV sends headers then stalls the body', async () => {
+    // Response headers arrive immediately, but the body never completes —
+    // reject only when the request is aborted (as undici would).
+    mockedFetch.mockImplementation((_url, opts) => Promise.resolve({
+      ok: true,
+      status: 200,
+      headers: new Headers(),
+      text: () => new Promise((_resolve, reject) => {
+        (opts as { signal: AbortSignal }).signal.addEventListener(
+          'abort',
+          () => reject(new Error('The operation was aborted')),
+        );
+      }),
+    } as never));
+
+    const promise = fetchWithTimeout('https://tv/6/sources', { method: 'GET' }, 2000);
+    const assertion = expect(promise).rejects.toThrow();
+    await vi.advanceTimersByTimeAsync(2000);
+    await assertion;
+  });
+
+  it('buffers the body and resolves on a normal response', async () => {
+    mockedFetch.mockResolvedValue({
+      ok: true,
+      status: 200,
+      headers: new Headers(),
+      text: () => Promise.resolve('{"sources":[{"id":"hdmi1"}]}'),
+    } as never);
+
+    const res = await fetchWithTimeout('https://tv/6/sources', { method: 'GET' }, 2000);
+
+    expect(res.ok).toBe(true);
+    expect(res.status).toBe(200);
+    expect(await res.text()).toBe('{"sources":[{"id":"hdmi1"}]}');
+    expect(await res.json()).toEqual({ sources: [{ id: 'hdmi1' }] });
   });
 });


### PR DESCRIPTION
## Summary

Fixes #14 — the setup wizard's "Fetching sources from TV" step hangs indefinitely and never shows sources.

**Root cause:** `fetchWithTimeout` armed its abort timer only around `fetch()`, which resolves as soon as the response **headers** arrive, then cleared the timer before the body was read. The body was read later via `response.text()` with no timeout. A TV that sends `200` headers then **stalls the body** (a known Philips-firmware behaviour on some models) left `getSources()` unresolved forever — so the spinner spun and the built-in-sources fallback was never reached.

**Fix:** `fetchWithTimeout` now reads the body while the abort timer is still armed and returns a response-like object with the buffered body (same `ok`/`status`/`headers`/`text()`/`json()` interface). A stalled body is aborted at the deadline. Fixing it in the shared helper also closes the same latent gap in the pairing and system-info paths.

## Verification

Reproduced with a local HTTPS server that sends headers then stalls the body:
- **Before:** `getSources()` hung >20s (never resolved).
- **After:** resolves in ~2s and falls back to the built-in sources.
- An unreachable IP already returned in ~4s (that path was guarded), which is why the bug wasn't obvious.

New regression tests in `test/api/utils.test.ts` cover the header-then-stall abort and the normal buffered-body path. **178 tests pass** (was 176), lint clean, `tsc` build clean.