### PR TITLE
fix(ui): stop the setup wizard's "Fetching sources" step from hanging

### DIFF
--- a/homebridge-ui/public/app.js
+++ b/homebridge-ui/public/app.js
@@ -106,6 +106,24 @@
   // API HELPERS
   // ============================================================================
 
+  /**
+   * Rejects with a friendly message if the wrapped promise doesn't settle in
+   * time. Used to guard IPC requests so the UI can never spin indefinitely.
+   */
+  const withTimeout = (promise, ms, message) => new Promise((resolve, reject) => {
+    const timer = setTimeout(() => reject(new Error(message)), ms);
+    promise.then(
+      (value) => {
+        clearTimeout(timer);
+        resolve(value);
+      },
+      (error) => {
+        clearTimeout(timer);
+        reject(error);
+      },
+    );
+  });
+
   const api = {
     discover: () => homebridge.request('/discover'),
     pair: (ip, deviceName) => homebridge.request('/pair', { ip, deviceName }),
@@ -693,7 +711,14 @@
 
   const loadSources = async (tv) => {
     try {
-      const result = await api.getSources(tv.ip, tv.username, tv.password, tv.mac);
+      // The server bounds its own fetch (~15s); this client-side guard is a
+      // last resort so a wedged request can never leave the spinner running
+      // forever — the user gets a retryable error instead.
+      const result = await withTimeout(
+        api.getSources(tv.ip, tv.username, tv.password, tv.mac),
+        20000,
+        'Timed out fetching sources from the TV. Make sure it is powered on, then retry.',
+      );
 
       if (result.success) {
         // Inject configured custom apps (the TV doesn't report these), then

--- a/homebridge-ui/server.js
+++ b/homebridge-ui/server.js
@@ -381,17 +381,22 @@ class UiServer extends HomebridgePluginUiServer {
       // momentarily-slow TV a longer chance to return its real source/app
       // list before falling back to the generic built-in list.
       const WIZARD_REQUEST_TIMEOUT_MS = 6000;
-      // Hard ceiling on the whole fetch so the "Fetching sources" spinner can
-      // never hang: whatever we have (or the built-in fallback) is returned
-      // once this deadline passes, even if the TV never answers.
+      // Hard ceiling on the whole fetch (sources + apps combined) so the
+      // "Fetching sources" spinner can never hang: whatever we have — or the
+      // built-in fallback — is returned once this budget is spent, even if the
+      // TV never answers. A TV freshly woken from standby can be slow to serve
+      // /applications (this reporter's TV returns 47 apps), so the budget is
+      // shared across both calls rather than applied to each.
       const WIZARD_TOTAL_DEADLINE_MS = 15000;
+      const deadline = Date.now() + WIZARD_TOTAL_DEADLINE_MS;
+      const remaining = () => Math.max(0, deadline - Date.now());
 
-      // Fetch sources from TV API (async call), bounded by an overall deadline
+      // Fetch sources from TV API (async call), bounded by the overall budget
       let tvSources = [];
       try {
         tvSources = await withDeadline(
           client.getSources(WIZARD_REQUEST_TIMEOUT_MS),
-          WIZARD_TOTAL_DEADLINE_MS,
+          remaining(),
         );
         console.log(`[Sources] Fetched ${tvSources.length} sources from TV API`);
       } catch (sourceError) {
@@ -412,7 +417,7 @@ class UiServer extends HomebridgePluginUiServer {
       try {
         apps = await withDeadline(
           client.getApplications(WIZARD_REQUEST_TIMEOUT_MS),
-          WIZARD_TOTAL_DEADLINE_MS,
+          remaining(),
         );
       } catch (appError) {
         console.log('[Sources] Could not fetch apps:', appError.message);

--- a/homebridge-ui/server.js
+++ b/homebridge-ui/server.js
@@ -25,6 +25,37 @@ import { PhilipsTVClient, HOME_URI, WATCH_TV_URI } from '../dist/api/PhilipsTVCl
 const getMAC = promisify(arp.getMAC);
 
 // ============================================================================
+// HELPERS
+// ============================================================================
+
+/**
+ * Races a promise against an overall deadline. If the deadline passes first,
+ * the returned promise rejects so the caller can fall back — guaranteeing a
+ * bounded response even if the underlying work never settles. The timer is
+ * unref'd so it never keeps the process alive on its own.
+ */
+function withDeadline(promise, ms) {
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(() => {
+      reject(new Error(`Timed out after ${ms}ms`));
+    }, ms);
+    if (typeof timer.unref === 'function') {
+      timer.unref();
+    }
+    promise.then(
+      (value) => {
+        clearTimeout(timer);
+        resolve(value);
+      },
+      (error) => {
+        clearTimeout(timer);
+        reject(error);
+      },
+    );
+  });
+}
+
+// ============================================================================
 // UI SERVER CLASS
 // ============================================================================
 
@@ -344,10 +375,24 @@ class UiServer extends HomebridgePluginUiServer {
         password: password || '',
       });
 
-      // Fetch sources from TV API (async call)
+      // The runtime client uses a short (2s) per-request timeout so it never
+      // exceeds HomeKit's characteristic callback deadline. The setup wizard
+      // has no such constraint and the user is actively waiting, so give a
+      // momentarily-slow TV a longer chance to return its real source/app
+      // list before falling back to the generic built-in list.
+      const WIZARD_REQUEST_TIMEOUT_MS = 6000;
+      // Hard ceiling on the whole fetch so the "Fetching sources" spinner can
+      // never hang: whatever we have (or the built-in fallback) is returned
+      // once this deadline passes, even if the TV never answers.
+      const WIZARD_TOTAL_DEADLINE_MS = 15000;
+
+      // Fetch sources from TV API (async call), bounded by an overall deadline
       let tvSources = [];
       try {
-        tvSources = await client.getSources();
+        tvSources = await withDeadline(
+          client.getSources(WIZARD_REQUEST_TIMEOUT_MS),
+          WIZARD_TOTAL_DEADLINE_MS,
+        );
         console.log(`[Sources] Fetched ${tvSources.length} sources from TV API`);
       } catch (sourceError) {
         console.log('[Sources] Could not fetch sources from TV, using built-in:', sourceError.message);
@@ -365,7 +410,10 @@ class UiServer extends HomebridgePluginUiServer {
       // Try to get apps from TV using the client
       let apps = [];
       try {
-        apps = await client.getApplications();
+        apps = await withDeadline(
+          client.getApplications(WIZARD_REQUEST_TIMEOUT_MS),
+          WIZARD_TOTAL_DEADLINE_MS,
+        );
       } catch (appError) {
         console.log('[Sources] Could not fetch apps:', appError.message);
       }

--- a/src/api/PhilipsTVClient.ts
+++ b/src/api/PhilipsTVClient.ts
@@ -355,9 +355,14 @@ export class PhilipsTVClient {
   /**
    * Fetches available sources from the TV API.
    * Falls back to built-in sources if the API call fails.
+   *
+   * An optional timeout override lets callers that are not bound by
+   * HomeKit's characteristic callback deadline (e.g. the setup wizard)
+   * give a momentarily-slow TV a longer chance to return real sources
+   * before falling back.
    */
-  async getSources(): Promise<TVSource[]> {
-    const result = await this.get<TVSourceList>('/sources');
+  async getSources(timeout?: number): Promise<TVSource[]> {
+    const result = await this.get<TVSourceList>('/sources', timeout);
     if (result?.sources && result.sources.length > 0) {
       return result.sources;
     }
@@ -399,8 +404,8 @@ export class PhilipsTVClient {
   // APPLICATIONS
   // ==========================================================================
 
-  async getApplications(): Promise<TVApplication[]> {
-    const result = await this.get<TVApplicationList>('/applications');
+  async getApplications(timeout?: number): Promise<TVApplication[]> {
+    const result = await this.get<TVApplicationList>('/applications', timeout);
     const apps = result?.applications ?? [];
 
     // Cache intents so launchApplication can use the correct className/action

--- a/test/api/PhilipsTVClient.test.ts
+++ b/test/api/PhilipsTVClient.test.ts
@@ -584,6 +584,62 @@ describe('PhilipsTVClient', () => {
 
       expect(result).toEqual([]);
     });
+
+    it('should forward a caller-supplied timeout to fetchWithTimeout', async () => {
+      mockFetch.mockReturnValue(mockResponse({ applications: [] }));
+
+      const promise = client.getApplications(6000);
+      await vi.runAllTimersAsync();
+      await promise;
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        expect.stringContaining('/applications'),
+        expect.any(Object),
+        6000,
+      );
+    });
+  });
+
+  // ==========================================================================
+  // SOURCES
+  // ==========================================================================
+
+  describe('getSources', () => {
+    it('should return the TV source list', async () => {
+      const sources = { sources: [{ id: 'hdmi1', name: 'HDMI 1' }] };
+      mockFetch.mockReturnValue(mockResponse(sources));
+
+      const promise = client.getSources();
+      await vi.runAllTimersAsync();
+      const result = await promise;
+
+      expect(result).toEqual([{ id: 'hdmi1', name: 'HDMI 1' }]);
+    });
+
+    it('should fall back to built-in sources when the TV returns none', async () => {
+      mockFetch.mockReturnValue(mockResponse(null, 500));
+
+      const promise = client.getSources();
+      await vi.runAllTimersAsync();
+      const result = await promise;
+
+      expect(result).toEqual(client.getBuiltInSources());
+      expect(result.length).toBeGreaterThan(0);
+    });
+
+    it('should forward a caller-supplied timeout to fetchWithTimeout', async () => {
+      mockFetch.mockReturnValue(mockResponse({ sources: [] }));
+
+      const promise = client.getSources(6000);
+      await vi.runAllTimersAsync();
+      await promise;
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        expect.stringContaining('/sources'),
+        expect.any(Object),
+        6000,
+      );
+    });
   });
 
   describe('launchApplication', () => {


### PR DESCRIPTION
## Summary

Fixes the recurrence of #14, where the setup wizard's **"Fetching sources from TV"** step could still hang or silently show the generic source list.

The v1.5.7 fix bounded the response-*body* read. This addresses a second, distinct cause surfaced by the reporter's logs: the failure correlates with **TV power state**, not with anything the user did. A Philips Android TV freshly woken from standby is slow to serve `/applications` (the reporter's TV returns **47 apps**). The wizard was driving the runtime client, which uses a deliberately short **2 s** per-request timeout tuned to stay under HomeKit's characteristic-callback deadline — so a momentarily-slow TV tripped it and the wizard quietly fell back to the generic built-in list (or, with nothing bounding the handler overall, kept spinning).

## Changes

- **`PhilipsTVClient.getSources()` / `getApplications()`** now accept an optional `timeout` override, forwarded to `fetchWithTimeout`. Runtime behavior is unchanged (still defaults to 2 s).
- **UI server (`getSources`)** passes a wizard-appropriate **6 s** per-request timeout and wraps the whole step in a **single shared 15 s deadline** across the sources + apps calls, falling back to built-in sources/apps if the budget is spent — so the handler always resolves. (The deadline is tracked as one wall-clock budget rather than applied per-call, so the worst case is 15 s total, not 30 s.)
- **Browser (`loadSources`)** adds a 20 s guard around the IPC request so a wedged request surfaces the existing retryable error instead of an infinite spinner.

## Tests

- Added client tests covering the timeout forwarding and the built-in-sources fallback.
- Full suite green (182 passing), lint clean, build passes.

## Notes / follow-ups (not in this PR)

- With 47 apps + inputs, the runtime accessory hits HomeKit's ~30-input cap (`Input source limit reached (30)`), so not all sources appear in HomeKit. Separate, pre-existing limitation — may warrant a README note.
- The wizard's `[Sources]` log lines live in the Homebridge UI log stream rather than the main plugin log, which made them hard for the reporter to find. Diagnostics-only; could be improved later.

Closes #14