### PR TITLE
Apply a scene's source once the TV has finished waking (#17)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [1.6.1] - 2026-08-03
+
+### Fixed
+
+- **A scene that turns the TV on and picks a source only turned the TV on** ([#17](https://github.com/mp-consulting/homebridge-philips-ambilight-tv/issues/17)): HomeKit writes the power and the source as two separate instructions at the same moment, with no guarantee of order, and the TV needs several seconds after accepting the power command before it will accept a launch. The plugin acted on the source instruction immediately, so it was sent to a TV that was off or still starting up, failed, and was never tried again — the TV came on and stayed where it was. A source chosen while the TV is off or still waking is now held and applied as soon as the TV is genuinely ready, retrying over about 12 seconds to cover a slow start. A source the TV refuses when it is properly awake still reports an error as before.
+
 ## [1.6.0] - 2026-08-03
 
 ### Security

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mp-consulting/homebridge-philips-ambilight-tv",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@mp-consulting/homebridge-philips-ambilight-tv",
-      "version": "1.6.0",
+      "version": "1.6.1",
       "license": "(Apache-2.0 AND MIT)",
       "dependencies": {
         "@homebridge/plugin-ui-utils": "^2.2.4",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@mp-consulting/homebridge-philips-ambilight-tv",
   "displayName": "Philips Ambilight TV",
   "type": "module",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "description": "Homebridge plugin to control Philips Ambilight TV as a HomeKit Television accessory.",
   "author": "Mickael Palma",
   "license": "(Apache-2.0 AND MIT)",

--- a/src/platformAccessory.ts
+++ b/src/platformAccessory.ts
@@ -12,6 +12,17 @@ import { StateSensorService } from './services/StateSensorService.js';
 import { AmbilightHueSwitchService } from './services/AmbilightHueSwitchService.js';
 
 // ============================================================================
+// CONSTANTS
+// ============================================================================
+
+/** How long after a power-on the TV is treated as possibly still booting, so a
+ *  rejected launch is retried rather than reported as a failure. The logs in
+ *  issue #14 show the TV confirming power 1-10s after the command, so this
+ *  covers that with margin while staying short enough that a launch the TV
+ *  genuinely refuses later still surfaces as an error. */
+const WAKE_WINDOW_MS = 20_000;
+
+// ============================================================================
 // PHILIPS AMBILIGHT TV ACCESSORY
 // ============================================================================
 
@@ -31,6 +42,10 @@ export class PhilipsAmbilightTVAccessory {
   private isPoweredOn = false;
   private isMuted = false;
   private powerSynced = false;
+
+  /** When the TV was last commanded on, used to tell a launch rejected by a
+   *  still-booting TV from one the TV genuinely refuses. */
+  private powerOnAt: number | null = null;
 
   constructor(
     private readonly platform: PhilipsAmbilightTVPlatform,
@@ -69,6 +84,8 @@ export class PhilipsAmbilightTVAccessory {
       log: (level, msg) => this.log(level, msg),
       onInputsChanged: () => this.refreshSourceSwitches(),
       onInputSwitched: (sourceId) => this.sourceSwitchService.updateFromPoll(sourceId),
+      isPoweredOn: () => this.isPoweredOn,
+      isWaking: () => this.isWaking(),
     });
 
     this.sourceSwitchService = new SourceSwitchService({
@@ -248,6 +265,7 @@ export class PhilipsAmbilightTVAccessory {
       const success = await this.tvClient.setPowerState(shouldBeOn);
       if (success) {
         this.isPoweredOn = shouldBeOn;
+        this.powerOnAt = shouldBeOn ? Date.now() : null;
         // Reflect a power-off immediately instead of waiting for the next poll
         // (up to the polling interval away), so the source switches don't linger
         // ON for several seconds after the user turns the TV off from HomeKit.
@@ -296,6 +314,15 @@ export class PhilipsAmbilightTVAccessory {
   // POLL CALLBACKS
   // ==========================================================================
 
+  /**
+   * True while the TV may still be booting. The TV acknowledges /powerstate
+   * long before its launcher will accept a launch, so a rejection inside this
+   * window means "not ready yet" rather than "refused".
+   */
+  private isWaking(): boolean {
+    return this.powerOnAt !== null && Date.now() - this.powerOnAt < WAKE_WINDOW_MS;
+  }
+
   private onPowerChange(isOn: boolean): void {
     // Skip the first sync so a Homebridge restart while the TV is already on
     // doesn't count as a power-on event (which would force Ambilight on).
@@ -314,13 +341,20 @@ export class PhilipsAmbilightTVAccessory {
       this.sourceSwitchService.resetAll();
       this.ambilightHueSwitchService.reset();
     } else if (!isInitialSync) {
-      // TV just powered on. A TV that was asleep at boot may not have reported
-      // its apps yet, so reconcile the input list now that it is reachable —
-      // this backfills any sources that couldn't be discovered at startup and
-      // refreshes the source switches to match (no restart required). Then pull
-      // the current source so the right input/switch lights up immediately
-      // rather than after the next poll (which can show the wrong/no switch).
-      void this.syncActiveSourceOnPowerOn();
+      if (this.inputSourceManager.hasPendingWakeSelection()) {
+        // A selection parked while the TV was off or booting takes priority
+        // over reading back whatever the TV happened to wake into — the user
+        // asked for a specific source and that request is still outstanding.
+        void this.inputSourceManager.replayWakeSelection();
+      } else {
+        // TV just powered on. A TV that was asleep at boot may not have reported
+        // its apps yet, so reconcile the input list now that it is reachable —
+        // this backfills any sources that couldn't be discovered at startup and
+        // refreshes the source switches to match (no restart required). Then pull
+        // the current source so the right input/switch lights up immediately
+        // rather than after the next poll (which can show the wrong/no switch).
+        void this.syncActiveSourceOnPowerOn();
+      }
       if (this.config.ambilightOnStart) {
         // Auto-start Ambilight in the configured mode.
         void this.ambilightService.startWithConfiguredMode();

--- a/src/services/InputSourceManager.ts
+++ b/src/services/InputSourceManager.ts
@@ -54,6 +54,23 @@ const PLAYTV_PACKAGE = 'org.droidtv.playtv';
 const AMBIGUOUS_CONFIRM_SIGHTINGS = 2;
 const AMBIGUOUS_CONFIRM_WINDOW_MS = 60_000;
 
+/** How long a selection made while the TV was off or waking is held for replay.
+ *  A HomeKit scene that turns the TV on and picks a source writes both
+ *  characteristics at once, but the TV needs several seconds to finish booting
+ *  before it will accept a launch — so the selection is parked and re-applied
+ *  once the TV is genuinely reachable. Long enough to cover a cold start from
+ *  deep standby, short enough that a selection never surfaces unexpectedly
+ *  much later. */
+const WAKE_REPLAY_WINDOW_MS = 90_000;
+
+/** Attempts made when replaying a parked selection. The TV answers /powerstate
+ *  while its launcher is still coming up, so a single try at the power-on edge
+ *  is not enough. Sized from the logs in issue #14: the earliest launch seen to
+ *  succeed after a wake landed 6s past the `Power: On` edge, so the retries
+ *  span 12s to leave real margin. */
+const WAKE_REPLAY_ATTEMPTS = 5;
+const WAKE_REPLAY_RETRY_MS = 3_000;
+
 /** TLV8 tags for DisplayOrder encoding */
 const TLV_ELEMENT_START = 0x01;
 const TLV_ELEMENT_END = 0x00;
@@ -183,6 +200,11 @@ export interface InputSourceManagerDeps {
   /** Called after a wheel selection successfully switched the TV, so the source
    *  switches light up immediately instead of waiting for the next poll. */
   readonly onInputSwitched?: (sourceId: string) => void;
+  /** Whether the TV is currently believed to be on. */
+  readonly isPoweredOn?: () => boolean;
+  /** Whether the TV was powered on recently enough that it may still be
+   *  booting and rejecting launches. */
+  readonly isWaking?: () => boolean;
 }
 
 // ============================================================================
@@ -203,6 +225,10 @@ export class InputSourceManager {
    *  ones, so a burst of wheel moves only launches the final choice. */
   private switchQueue: Promise<void> = Promise.resolve();
   private switchGeneration = 0;
+
+  /** Selection made while the TV was off or still waking, held until the TV is
+   *  reachable. See WAKE_REPLAY_WINDOW_MS. */
+  private wakeSelection: { input: InputSource; parkedAt: number } | null = null;
 
   /** Tracks consecutive sightings of an ambiguous system report (NA / playtv)
    *  so a lone transitional report is never applied. See AMBIGUOUS_CONFIRM_*. */
@@ -479,6 +505,16 @@ export class InputSourceManager {
 
     this.deps.log('info', `Switching to: ${inputSource.name}`);
 
+    // The TV is off. A HomeKit scene that turns the TV on and picks a source
+    // writes Active and ActiveIdentifier as two independent characteristics
+    // with no ordering guarantee, so this can arrive before the power-on has
+    // even been sent. Launching now would fail against a TV that is not up;
+    // park the choice and apply it when the TV reports in.
+    if (this.deps.isPoweredOn?.() === false) {
+      this.parkForWake(inputSource, 'TV is off');
+      return;
+    }
+
     // Coalesce bursts of wheel moves: launches run one at a time, and a
     // selection that is superseded while waiting is skipped entirely. Without
     // this, every intermediate selection launched on the TV back-to-back —
@@ -516,6 +552,15 @@ export class InputSourceManager {
         throw this.deps.communicationError();
       }
     } catch (error) {
+      // The TV acknowledges /powerstate well before its launcher is ready, so
+      // a launch fired moments after a power-on can be rejected by a TV that is
+      // still booting. Park it rather than reporting failure — the same scene
+      // case as above, just with the power write having landed first.
+      if (this.deps.isWaking?.()) {
+        this.parkForWake(inputSource, 'TV is still waking');
+        return;
+      }
+
       if (inputSource.type === 'app') {
         // The TV rejects a launch with the wrong activity — a common cause for
         // custom apps whose launch activity isn't the guessed default.
@@ -528,6 +573,81 @@ export class InputSourceManager {
       }
       throw error instanceof Error && 'hapStatus' in error ? error : this.deps.communicationError();
     }
+  }
+
+  // ==========================================================================
+  // DEFERRED SELECTION (TV off or waking)
+  // ==========================================================================
+
+  /**
+   * Hold a selection the TV cannot act on yet and show it as chosen in
+   * HomeKit. Reporting an error instead would bounce the wheel back and make
+   * the scene look broken, when the request is simply early.
+   */
+  private parkForWake(input: InputSource, reason: string): void {
+    this.wakeSelection = { input, parkedAt: Date.now() };
+    this.currentInputId = input.identifier;
+    this.tvService?.updateCharacteristic(this.deps.Characteristic.ActiveIdentifier, input.identifier);
+    this.deps.log('info', `${reason} — will switch to ${input.name} once it is ready`);
+
+    // If the TV already reports on, the power-on edge that drives the replay
+    // has been and gone, so nothing else would ever pick this up — retry from
+    // here instead. When the TV is still off the edge is yet to come and
+    // onPowerChange takes it.
+    if (this.deps.isPoweredOn?.() === true) {
+      void this.replayWakeSelection();
+    }
+  }
+
+  /** True when a selection is waiting to be applied on wake. */
+  hasPendingWakeSelection(): boolean {
+    return this.wakeSelection !== null;
+  }
+
+  /**
+   * Apply a selection parked while the TV was off or waking. Called on the
+   * power-on edge, once the TV has answered a poll and is reachable.
+   */
+  async replayWakeSelection(): Promise<void> {
+    const parked = this.wakeSelection;
+    this.wakeSelection = null;
+
+    if (!parked) {
+      return;
+    }
+
+    if (Date.now() - parked.parkedAt > WAKE_REPLAY_WINDOW_MS) {
+      this.deps.log('debug', `Discarding stale pending switch to ${parked.input.name}`);
+      return;
+    }
+
+    for (let attempt = 1; attempt <= WAKE_REPLAY_ATTEMPTS; attempt++) {
+      // A newer selection while we were waiting wins — the user has moved on.
+      if (this.wakeSelection !== null) {
+        return;
+      }
+
+      try {
+        if (await this.switchInput(parked.input)) {
+          this.currentInputId = parked.input.identifier;
+          this.markPending(parked.input.identifier);
+          this.tvService?.updateCharacteristic(
+            this.deps.Characteristic.ActiveIdentifier, parked.input.identifier,
+          );
+          this.deps.onInputSwitched?.(parked.input.id);
+          this.deps.log('info', `Switched to ${parked.input.name} after wake`);
+          return;
+        }
+      } catch {
+        // Fall through to the retry — a TV mid-boot rejects launches.
+      }
+
+      if (attempt < WAKE_REPLAY_ATTEMPTS) {
+        await new Promise(resolve => setTimeout(resolve, WAKE_REPLAY_RETRY_MS));
+      }
+    }
+
+    this.deps.log('warn', `Could not switch to ${parked.input.name} after the TV woke up`);
   }
 
   // ==========================================================================

--- a/test/platformAccessory.test.ts
+++ b/test/platformAccessory.test.ts
@@ -20,6 +20,8 @@ const mocks = vi.hoisted(() => ({
   fetchAppsFromTV: vi.fn().mockResolvedValue(undefined),
   inputUpdateFromPoll: vi.fn(),
   switchUpdateFromPoll: vi.fn(),
+  hasPendingWakeSelection: vi.fn().mockReturnValue(false),
+  replayWakeSelection: vi.fn().mockResolvedValue(undefined),
 }));
 
 /** Holder for the poll callbacks the accessory hands to StatePollManager,
@@ -56,6 +58,8 @@ vi.mock('../src/services/InputSourceManager.js', () => ({
     updateFromPoll = mocks.inputUpdateFromPoll;
     setActiveInputById = vi.fn();
     fetchAppsFromTV = mocks.fetchAppsFromTV;
+    hasPendingWakeSelection = mocks.hasPendingWakeSelection;
+    replayWakeSelection = mocks.replayWakeSelection;
     constructor(deps: unknown) {
       capture.inputManagerDeps = deps;
     }
@@ -210,6 +214,8 @@ describe('PhilipsAmbilightTVAccessory power handling', () => {
     Object.values(mocks).forEach(m => m.mockClear());
     mocks.setPowerState.mockResolvedValue(true);
     mocks.getVisibleSources.mockReturnValue([]);
+    mocks.hasPendingWakeSelection.mockReturnValue(false);
+    mocks.replayWakeSelection.mockResolvedValue(undefined);
     // Mirror the real InputSourceManager contract: return the accepted id.
     mocks.inputUpdateFromPoll.mockImplementation((app: string | null) => app);
   });

--- a/test/services/InputSourceManager.test.ts
+++ b/test/services/InputSourceManager.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { InputSourceManager } from '../../src/services/InputSourceManager.js';
 import type { InputSourceManagerDeps } from '../../src/services/InputSourceManager.js';
+import { WATCH_TV_URI } from '../../src/api/PhilipsTVClient.js';
 
 // ============================================================================
 // MOCKS
@@ -706,6 +707,149 @@ describe('InputSourceManager', () => {
       manager.configureInputSources(tvService as never);
 
       await expect(manager.handleSetInput(999)).rejects.toThrow();
+    });
+  });
+
+  // ==========================================================================
+  // DEFERRED SELECTION WHILE THE TV WAKES (issue #17)
+  // ==========================================================================
+
+  describe('selection made while the TV is off or waking', () => {
+    const APP = {
+      name: 'EON',
+      packageName: 'com.ug.eon.android.tv',
+      className: 'com.ug.eon.android.tv.MainActivity',
+    };
+
+    /** A HomeKit scene writes Active and ActiveIdentifier at the same time. */
+    const setup = (overrides: Record<string, unknown> = {}) => {
+      const deps = createMockDeps({ customApps: [APP], ...overrides });
+      const manager = new InputSourceManager(deps);
+      const tvService = createMockService();
+      manager.configureInputSources(tvService as never);
+      const app = manager.getSources().find(s => s.id === 'com.ug.eon.android.tv')!;
+      return { deps, manager, tvService, app };
+    };
+
+    it('should park the selection instead of launching into a TV that is off', async () => {
+      const { deps, manager, app } = setup({ isPoweredOn: () => false });
+
+      await manager.handleSetInput(app.identifier);
+
+      expect(deps.tvClient.launchApplication).not.toHaveBeenCalled();
+      expect(manager.hasPendingWakeSelection()).toBe(true);
+    });
+
+    it('should show the parked selection as chosen rather than erroring', async () => {
+      const { manager, tvService, app } = setup({ isPoweredOn: () => false });
+
+      // Throwing here would bounce the wheel back and make the scene look broken.
+      await expect(manager.handleSetInput(app.identifier)).resolves.toBeUndefined();
+      expect(tvService.updateCharacteristic).toHaveBeenCalledWith(
+        expect.objectContaining({ UUID: 'active-identifier' }), app.identifier,
+      );
+    });
+
+    it('should apply the parked selection when the TV wakes', async () => {
+      const { deps, manager, app } = setup({ isPoweredOn: () => false });
+      await manager.handleSetInput(app.identifier);
+
+      await manager.replayWakeSelection();
+
+      expect(deps.tvClient.launchApplication).toHaveBeenCalledWith(
+        'com.ug.eon.android.tv', 'com.ug.eon.android.tv.MainActivity', undefined,
+      );
+      expect(manager.hasPendingWakeSelection()).toBe(false);
+    });
+
+    it('should park a launch the TV rejects while it is still booting', async () => {
+      const { deps, manager, app } = setup({ isPoweredOn: () => true, isWaking: () => true });
+      const launch = deps.tvClient.launchApplication as ReturnType<typeof vi.fn>;
+      launch.mockResolvedValue(false);
+
+      // The power write landed first, so the TV reports on but is not ready.
+      await expect(manager.handleSetInput(app.identifier)).resolves.toBeUndefined();
+
+      // The TV already reports on, so the power-on edge has passed and the
+      // retry has to come from the park itself.
+      launch.mockResolvedValue(true);
+      await vi.advanceTimersByTimeAsync(5000);
+      expect(launch.mock.calls.length).toBeGreaterThan(1);
+    });
+
+    it('should still report a failure when the TV is up and refuses the launch', async () => {
+      const { deps, manager, app } = setup({ isPoweredOn: () => true, isWaking: () => false });
+      (deps.tvClient.launchApplication as ReturnType<typeof vi.fn>).mockResolvedValue(false);
+
+      await expect(manager.handleSetInput(app.identifier)).rejects.toThrow();
+      expect(manager.hasPendingWakeSelection()).toBe(false);
+    });
+
+    it('should retry a replay that the TV rejects mid-boot', async () => {
+      const { deps, manager, app } = setup({ isPoweredOn: () => false });
+      await manager.handleSetInput(app.identifier);
+
+      const launch = deps.tvClient.launchApplication as ReturnType<typeof vi.fn>;
+      launch.mockResolvedValueOnce(false).mockResolvedValueOnce(true);
+
+      const replay = manager.replayWakeSelection();
+      await vi.advanceTimersByTimeAsync(4000);
+      await replay;
+
+      expect(launch).toHaveBeenCalledTimes(2);
+    });
+
+    it('should give up after the retry budget and warn', async () => {
+      const { deps, manager, app } = setup({ isPoweredOn: () => false });
+      await manager.handleSetInput(app.identifier);
+      (deps.tvClient.launchApplication as ReturnType<typeof vi.fn>).mockResolvedValue(false);
+
+      const replay = manager.replayWakeSelection();
+      await vi.advanceTimersByTimeAsync(20_000);
+      await replay;
+
+      expect(deps.log).toHaveBeenCalledWith('warn', expect.stringContaining('Could not switch to'));
+      expect(manager.hasPendingWakeSelection()).toBe(false);
+    });
+
+    it('should discard a selection parked too long ago', async () => {
+      const { deps, manager, app } = setup({ isPoweredOn: () => false });
+      await manager.handleSetInput(app.identifier);
+
+      // Longer than WAKE_REPLAY_WINDOW_MS — the user is not still waiting.
+      vi.setSystemTime(Date.now() + 120_000);
+      await manager.replayWakeSelection();
+
+      expect(deps.tvClient.launchApplication).not.toHaveBeenCalled();
+    });
+
+    it('should let a newer selection supersede a parked one', async () => {
+      const { deps, manager, app } = setup({ isPoweredOn: () => false });
+      const watchTv = manager.getSources().find(s => s.id === WATCH_TV_URI)!;
+
+      await manager.handleSetInput(app.identifier);
+      await manager.handleSetInput(watchTv.identifier);
+      await manager.replayWakeSelection();
+
+      expect(deps.tvClient.launchWatchTV).toHaveBeenCalled();
+      expect(deps.tvClient.launchApplication).not.toHaveBeenCalled();
+    });
+
+    it('should switch normally when the TV is already on', async () => {
+      const { deps, manager, app } = setup({ isPoweredOn: () => true, isWaking: () => false });
+
+      await manager.handleSetInput(app.identifier);
+
+      expect(deps.tvClient.launchApplication).toHaveBeenCalled();
+      expect(manager.hasPendingWakeSelection()).toBe(false);
+    });
+
+    it('should switch normally when no power hooks are supplied', async () => {
+      const { deps, manager, app } = setup();
+
+      await manager.handleSetInput(app.identifier);
+
+      expect(deps.tvClient.launchApplication).toHaveBeenCalled();
     });
   });
 


### PR DESCRIPTION
Fixes #17.

## The problem

A Home app scene set to "TV + source" turns the TV on but never switches to the app.

HomeKit writes `Active` and `ActiveIdentifier` as two independent characteristics at the same moment, with no ordering guarantee — so the source instruction can arrive before the power-on has even been sent. And even when power lands first, the TV acknowledges `/powerstate` well before its launcher will accept a launch.

`InputSourceManager` had no notion of power state at all: it launched immediately in both cases, against a TV that was off or still booting. The launch failed, `performSwitch` logged a warning and threw, and nothing ever retried. TV on, source unchanged.

## The fix

A selection made while the TV is off — or rejected while it is still waking — is parked and replayed once the TV is reachable.

- **Parking does not throw.** HomeKit shows the input as selected. Raising an error would bounce the wheel back and make the scene look broken, when the request is merely early.
- **A parked selection outranks `syncActiveSourceOnPowerOn`.** The user asked for a specific source; that beats reading back whatever the TV happened to boot into.
- **A launch the TV refuses when properly awake still errors**, so genuine failures (e.g. a wrong launch activity) are not swallowed.

Guards: 90s parking window, a newer selection supersedes a parked one, and when the TV already reports on the retry runs from the park itself rather than waiting for a power-on edge that has already passed.

## Timings

Taken from the logs in #14 rather than guessed:

| Date | `Setting power to ON` | `Power: On` | Lag |
|---|---|---|---|
| 7/9 | 23:22:10 | 23:22:11 | 1s |
| 7/13 | 16:14:53 | 16:15:02 | 9s |
| 7/13 | 23:29:34 | 23:29:44 | 10s |

The earliest launch observed to succeed after a wake landed 6s past the `Power: On` edge, so the replay retries across 12s and the wake window is 20s.

## Testing

273 tests pass, lint clean, build clean. 11 new tests; reverting the two deferral paths fails 6 of them, so they are real guards.

**Not verified against hardware.** The reporter never posted a log for #17, so the mechanism is inferred from the code — the timings above are real, the diagnosis is not yet confirmed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)