### PR TITLE
fix(ui): drop sourceMappingURL refs from the vendored Bootstrap

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "homebridge": "^1.8.0 || ^2.0.0-beta.0"
   },
   "scripts": {
-    "copy:ui-assets": "mkdir -p homebridge-ui/public/lib/fonts && cp node_modules/@mp-consulting/homebridge-ui-kit/dist/kit.css node_modules/@mp-consulting/homebridge-ui-kit/dist/kit.js homebridge-ui/public/lib/ && cp node_modules/bootstrap/dist/css/bootstrap.min.css node_modules/bootstrap/dist/js/bootstrap.bundle.min.js homebridge-ui/public/lib/ && cp node_modules/bootstrap-icons/font/bootstrap-icons.min.css homebridge-ui/public/lib/ && cp node_modules/bootstrap-icons/font/fonts/bootstrap-icons.woff node_modules/bootstrap-icons/font/fonts/bootstrap-icons.woff2 homebridge-ui/public/lib/fonts/",
+    "copy:ui-assets": "mkdir -p homebridge-ui/public/lib/fonts && cp node_modules/@mp-consulting/homebridge-ui-kit/dist/kit.css node_modules/@mp-consulting/homebridge-ui-kit/dist/kit.js homebridge-ui/public/lib/ && cp node_modules/bootstrap/dist/css/bootstrap.min.css node_modules/bootstrap/dist/js/bootstrap.bundle.min.js homebridge-ui/public/lib/ && cp node_modules/bootstrap-icons/font/bootstrap-icons.min.css homebridge-ui/public/lib/ && cp node_modules/bootstrap-icons/font/fonts/bootstrap-icons.woff node_modules/bootstrap-icons/font/fonts/bootstrap-icons.woff2 homebridge-ui/public/lib/fonts/ && perl -pi -e 's{^\\s*/[*/]# sourceMappingURL=.*$}{}' homebridge-ui/public/lib/bootstrap.min.css homebridge-ui/public/lib/bootstrap.bundle.min.js",
     "build": "npm run copy:ui-assets && rimraf ./dist && tsc",
     "lint": "eslint . --max-warnings=0",
     "prepublishOnly": "npm test && npm run lint && npm run build",


### PR DESCRIPTION
Console noise only, no functional change.

The minified Bootstrap files end with a `sourceMappingURL` comment, so the browser requested the two `.map` files we do not vendor and logged 404s on every visit to the settings page:

```
Failed to load resource: 404 (bootstrap.min.css.map)
Failed to load resource: 404 (bootstrap.bundle.min.js.map)
```

Shipping the maps would cost ~920 kB (590 kB CSS + 332 kB JS) for something only visible with devtools open — real weight on a Raspberry Pi — so the `copy:ui-assets` step strips the trailing comment instead:

```
perl -pi -e 's{^\s*/[*/]# sourceMappingURL=.*$}{}' .../bootstrap.min.css .../bootstrap.bundle.min.js
```

Verified by deleting both vendored files and rebuilding from scratch: zero `sourceMappingURL` references remain, `node --check` still parses the JS bundle, and the CSS brace count stays balanced.